### PR TITLE
Orbit controls revisions

### DIFF
--- a/examples/camera-updates/src/main.ts
+++ b/examples/camera-updates/src/main.ts
@@ -26,6 +26,7 @@ async function main() {
     };
 
     const onKeyDown = (event: KeyboardEvent) => {
+        // Use i, j, k, l to move the camera around
         let translation = new SPLAT.Vector3();
         if (event.key === "j") {
             translation = translation.add(new SPLAT.Vector3(-1, 0, 0));
@@ -41,6 +42,13 @@ async function main() {
         }
         camera.position = camera.position.add(translation);
 
+        // Use u to set a random look target near the origin
+        if (event.key === "u") {
+            const target = new SPLAT.Vector3(Math.random() - 0.5, Math.random() - 0.5, Math.random() - 0.5);
+            controls.setCameraTarget(target);
+        }
+
+        // Use space to reset the camera
         if (event.key === " ") {
             camera.position = new SPLAT.Vector3();
             camera.rotation = new SPLAT.Quaternion();

--- a/src/controls/OrbitControls.ts
+++ b/src/controls/OrbitControls.ts
@@ -12,11 +12,9 @@ class OrbitControls {
     panSpeed: number = 1;
     zoomSpeed: number = 1;
     dampening: number = 0.12;
-    setCameraPosition: (position: Vector3, lookAt: Vector3) => void = () => { };
-
-    setCameraLookAt: (lookAt: Vector3) => void = () => { };
-    attach: (newCamera: Camera) => void = () => { };
-    detach: () => void = () => { };
+    setCameraTarget: (newTarget: Vector3) => void = () => {};
+    attach: (newCamera: Camera) => void = () => {};
+    detach: () => void = () => {};
     update: () => void;
     dispose: () => void;
 
@@ -77,6 +75,17 @@ class OrbitControls {
         };
 
         this.attach(inputCamera);
+
+        this.setCameraTarget = (newTarget: Vector3) => {
+            if (!camera) return;
+            const dx = newTarget.x - camera.position.x;
+            const dy = newTarget.y - camera.position.y;
+            const dz = newTarget.z - camera.position.z;
+            desiredAlpha = Math.sqrt(dx * dx + dy * dy + dz * dz);
+            desiredBeta = Math.atan2(dy, Math.sqrt(dx * dx + dz * dz));
+            desiredRadius = -Math.atan2(dx, dz);
+            desiredTarget.set(newTarget.x, newTarget.y, newTarget.z);
+        };
 
         const computeZoomNorm = () => {
             return 0.1 + (0.9 * (desiredRadius - this.minZoom)) / (this.maxZoom - this.minZoom);
@@ -228,38 +237,6 @@ class OrbitControls {
         const lerp = (a: number, b: number, t: number) => {
             return (1 - t) * a + t * b;
         };
-        this.setCameraPosition = (position: Vector3, lookAt: Vector3) => {
-            if (!lookAt) {
-                desiredTarget.x = position.x - radius * Math.sin(alpha) * Math.cos(beta);
-                desiredTarget.y = position.y + radius * Math.sin(beta);
-                desiredTarget.z = position.z + radius * Math.cos(alpha) * Math.cos(beta);
-            }
-            else {
-                let dx = lookAt.x - position.x;
-                let dy = lookAt.y - position.y;
-                let dz = lookAt.z - position.z;
-                const _radius = Math.sqrt(dx * dx + dy * dy + dz * dz);
-                const _beta = Math.atan2(dy, Math.sqrt(dx * dx + dz * dz));
-                const _alpha = -Math.atan2(dx, dz);
-                desiredAlpha = _alpha;
-                desiredBeta = _beta;
-                desiredRadius = _radius;
-                desiredTarget.set(lookAt.x, lookAt.y, lookAt.z);
-            }
-        }
-        this.setCameraLookAt = (lookAt: Vector3) => {
-            if (!camera) return;
-            let dx = lookAt.x - camera.position.x;
-            let dy = lookAt.y - camera.position.y;
-            let dz = lookAt.z - camera.position.z;
-            const _radius = Math.sqrt(dx * dx + dy * dy + dz * dz);
-            const _beta = Math.atan2(dy, Math.sqrt(dx * dx + dz * dz));
-            const _alpha = -Math.atan2(dx, dz);
-            desiredAlpha = _alpha;
-            desiredBeta = _beta;
-            desiredRadius = _radius;
-            desiredTarget.set(lookAt.x, lookAt.y, lookAt.z);
-        }
 
         this.update = () => {
             if (!camera) return;

--- a/src/controls/OrbitControls.ts
+++ b/src/controls/OrbitControls.ts
@@ -12,8 +12,10 @@ class OrbitControls {
     panSpeed: number = 1;
     zoomSpeed: number = 1;
     dampening: number = 0.12;
-    attach: (newCamera: Camera) => void = () => {};
-    detach: () => void = () => {};
+    setCameraPosition: (x: number, y: number, z: number) => void = () => { };
+    setCameraLookAt: (x: number, y: number, z: number) => void = () => { };
+    attach: (newCamera: Camera) => void = () => { };
+    detach: () => void = () => { };
     update: () => void;
     dispose: () => void;
 
@@ -225,7 +227,26 @@ class OrbitControls {
         const lerp = (a: number, b: number, t: number) => {
             return (1 - t) * a + t * b;
         };
-
+        this.setCameraLookAt = (newX: number, newY: number, newZ: number) => {
+            if (!camera) return;
+            let dx = newX - camera.position.x;
+            let dy = newY - camera.position.y;
+            let dz = newZ - camera.position.z;
+            const _radius = Math.sqrt(dx * dx + dy * dy + dz * dz);
+            const _beta = Math.atan2(dy, Math.sqrt(dx * dx + dz * dz));
+            const _alpha = -Math.atan2(dx, dz);
+            desiredAlpha = _alpha;
+            desiredBeta = _beta;
+            desiredRadius = _radius;
+            desiredTarget.set(newX, newY, newZ);
+            this.update();
+        }
+        this.setCameraPosition = (x: number, y: number, z: number) => {
+            desiredTarget.x = x - radius * Math.sin(alpha) * Math.cos(beta);
+            desiredTarget.y = y + radius * Math.sin(beta);
+            desiredTarget.z = z + radius * Math.cos(alpha) * Math.cos(beta);
+            this.update();
+        }
         this.update = () => {
             if (!camera) return;
 

--- a/src/controls/OrbitControls.ts
+++ b/src/controls/OrbitControls.ts
@@ -227,18 +227,18 @@ class OrbitControls {
         const lerp = (a: number, b: number, t: number) => {
             return (1 - t) * a + t * b;
         };
-        this.setCameraLookAt = (newX: number, newY: number, newZ: number) => {
+        this.setCameraLookAt = (x: number, y: number, z: number) => {
             if (!camera) return;
-            let dx = newX - camera.position.x;
-            let dy = newY - camera.position.y;
-            let dz = newZ - camera.position.z;
+            let dx = x - camera.position.x;
+            let dy = y - camera.position.y;
+            let dz = z - camera.position.z;
             const _radius = Math.sqrt(dx * dx + dy * dy + dz * dz);
             const _beta = Math.atan2(dy, Math.sqrt(dx * dx + dz * dz));
             const _alpha = -Math.atan2(dx, dz);
             desiredAlpha = _alpha;
             desiredBeta = _beta;
             desiredRadius = _radius;
-            desiredTarget.set(newX, newY, newZ);
+            desiredTarget.set(x, y, z);
             this.update();
         }
         this.setCameraPosition = (x: number, y: number, z: number) => {

--- a/src/controls/OrbitControls.ts
+++ b/src/controls/OrbitControls.ts
@@ -12,8 +12,9 @@ class OrbitControls {
     panSpeed: number = 1;
     zoomSpeed: number = 1;
     dampening: number = 0.12;
-    setCameraPosition: (x: number, y: number, z: number) => void = () => { };
-    setCameraLookAt: (x: number, y: number, z: number) => void = () => { };
+    setCameraPosition: (position: Vector3, lookAt: Vector3) => void = () => { };
+
+    setCameraLookAt: (lookAt: Vector3) => void = () => { };
     attach: (newCamera: Camera) => void = () => { };
     detach: () => void = () => { };
     update: () => void;
@@ -227,26 +228,39 @@ class OrbitControls {
         const lerp = (a: number, b: number, t: number) => {
             return (1 - t) * a + t * b;
         };
-        this.setCameraLookAt = (x: number, y: number, z: number) => {
+        this.setCameraPosition = (position: Vector3, lookAt: Vector3) => {
+            if (!lookAt) {
+                desiredTarget.x = position.x - radius * Math.sin(alpha) * Math.cos(beta);
+                desiredTarget.y = position.y + radius * Math.sin(beta);
+                desiredTarget.z = position.z + radius * Math.cos(alpha) * Math.cos(beta);
+            }
+            else {
+                let dx = lookAt.x - position.x;
+                let dy = lookAt.y - position.y;
+                let dz = lookAt.z - position.z;
+                const _radius = Math.sqrt(dx * dx + dy * dy + dz * dz);
+                const _beta = Math.atan2(dy, Math.sqrt(dx * dx + dz * dz));
+                const _alpha = -Math.atan2(dx, dz);
+                desiredAlpha = _alpha;
+                desiredBeta = _beta;
+                desiredRadius = _radius;
+                desiredTarget.set(lookAt.x, lookAt.y, lookAt.z);
+            }
+        }
+        this.setCameraLookAt = (lookAt: Vector3) => {
             if (!camera) return;
-            let dx = x - camera.position.x;
-            let dy = y - camera.position.y;
-            let dz = z - camera.position.z;
+            let dx = lookAt.x - camera.position.x;
+            let dy = lookAt.y - camera.position.y;
+            let dz = lookAt.z - camera.position.z;
             const _radius = Math.sqrt(dx * dx + dy * dy + dz * dz);
             const _beta = Math.atan2(dy, Math.sqrt(dx * dx + dz * dz));
             const _alpha = -Math.atan2(dx, dz);
             desiredAlpha = _alpha;
             desiredBeta = _beta;
             desiredRadius = _radius;
-            desiredTarget.set(x, y, z);
-            this.update();
+            desiredTarget.set(lookAt.x, lookAt.y, lookAt.z);
         }
-        this.setCameraPosition = (x: number, y: number, z: number) => {
-            desiredTarget.x = x - radius * Math.sin(alpha) * Math.cos(beta);
-            desiredTarget.y = y + radius * Math.sin(beta);
-            desiredTarget.z = z + radius * Math.cos(alpha) * Math.cos(beta);
-            this.update();
-        }
+
         this.update = () => {
             if (!camera) return;
 


### PR DESCRIPTION
- Naming, formatting for consistency
- Removed `setPosition`, since I believe it has the same function as setting `camera.position =` directly, which OrbitControls now listens for. Let me know if I'm mistaken and there is a different intended functionality
- Update the camera-updates example to test the new method